### PR TITLE
Add ability to use logical AND for tags

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,10 +9,28 @@ module.exports = function (grunt) {
       }
     },
     cucumberjs: {
-      files: 'features',
-      options: {
-        steps: 'features/step_definitions',
-        format: 'pretty'
+      test1: {
+        files: 'features',
+        options: {
+          steps: 'features/step_definitions',
+          format: 'pretty'
+        }
+      },
+      test2: {
+        files: 'features',
+        options: {
+          steps: 'features/step_definitions',
+          format: 'pretty',
+          tags: '@tag'
+        }
+      },
+      test3: {
+        files: 'features',
+        options: {
+          steps: 'features/step_definitions',
+          format: 'pretty',
+          tags: ['~@wip', '@tag']
+        }
       }
     }
   });
@@ -21,5 +39,7 @@ module.exports = function (grunt) {
 
   grunt.loadTasks('tasks');
 
-  grunt.registerTask('default', ['jshint', 'cucumberjs']);
+  grunt.registerTask('default', ['jshint', 'cucumberjs:test1']);
+
+  grunt.registerTask('tag-tests', ['cucumberjs:test2', 'cucumberjs:test3'])
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,7 @@ module.exports = function (grunt) {
         }
       },
       test2: {
-        files: 'features',
+        files: 'features/tags.feature',
         options: {
           steps: 'features/step_definitions',
           format: 'pretty',
@@ -25,11 +25,19 @@ module.exports = function (grunt) {
         }
       },
       test3: {
-        files: 'features',
+        files: 'features/tags.feature',
         options: {
           steps: 'features/step_definitions',
           format: 'pretty',
-          tags: ['~@wip', '@tag']
+          tags: ['@wip', '~@tag']
+        }
+      },
+      test4: {
+        files: 'features/tags.feature',
+        options: {
+          steps: 'features/step_definitions',
+          format: 'pretty',
+          tags: ['@wip', '@tag']
         }
       }
     }
@@ -41,5 +49,5 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', ['jshint', 'cucumberjs:test1']);
 
-  grunt.registerTask('tag-tests', ['cucumberjs:test2', 'cucumberjs:test3'])
+  grunt.registerTask('tag-tests', ['cucumberjs:test2', 'cucumberjs:test3', 'cucumberjs:test4'])
 };

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ this represents boolean NOT. Example:
 by a comma, which represents logical OR. Example:
 `tags: '@dev,@wip'`
 
-To represent a logcal AND, use an array.
+To represent a logical AND, use an array.
 This is useful if you want to skip certain features
-and run other specific (tagged) features. Example:
+and run other specific features. Example:
 `tags: ['~@wip', '@dev']`
 
 #### format

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ when this option is specified, and all loading becomes explicit.
 Files under directories named "support" are always loaded first.
 
 #### tags
-Type: `String`
+Type: `String` or `Array`
 
 Default: `''`
 
@@ -57,6 +57,11 @@ this represents boolean NOT. Example:
  A tag expression can have several tags separated
 by a comma, which represents logical OR. Example:
 `tags: '@dev,@wip'`
+
+To represent a logcal AND, use an array.
+This is useful if you want to skip certain features
+and run other specific (tagged) features. Example:
+`tags: ['~@wip', '@dev']`
 
 #### format
 Type: `String`

--- a/features/tags.feature
+++ b/features/tags.feature
@@ -1,0 +1,27 @@
+Feature: Testing tags
+  As a grunt-cucumber-js dev
+  I want a Testing.feature file with tags
+  So that I can test the tag functionality of cucumber-js-task
+
+  @wip
+  Scenario: Tagged wip
+    Given I have the number 1 and 3
+    When I add them together
+    Then I should have 4
+
+  @tag
+  Scenario: Tagged tag
+    Given I have the number 1 and 3
+    When I add them together
+    Then I should have 4
+
+  Scenario: No tags
+    Given I have the number 1 and 3
+    When I add them together
+    Then I should have 4
+
+  @wip @tag
+  Scenario: Tagged wip and tag
+    Given I have the number 1 and 3
+    When I add them together
+    Then I should have 4

--- a/tasks/cucumber-js-task.js
+++ b/tasks/cucumber-js-task.js
@@ -53,7 +53,7 @@ module.exports = function (grunt) {
     }
 
     if (! _.isEmpty(tags)) {
-      if (typeof tags == "string") {
+      if (typeof tags === "string") {
        tags = [tags];
       }
       for (var i=0; i < tags.length; i++) {

--- a/tasks/cucumber-js-task.js
+++ b/tasks/cucumber-js-task.js
@@ -53,8 +53,13 @@ module.exports = function (grunt) {
     }
 
     if (! _.isEmpty(tags)) {
-      execOptions.push('-t');
-      execOptions.push(tags);
+      if (typeof tags == "string") {
+       tags = [tags];
+      }
+      for (var i=0; i < tags.length; i++) {
+       execOptions.push('-t');
+       execOptions.push(tags[i]);
+      }
     }
 
     if (! _.isEmpty(format)) {


### PR DESCRIPTION
Using arrays allows adding `-t @tag -t @secondtag` to perform a logical AND. I tried setting `tags: "@tag1 -t @tag2" but that didn't work, so this is a way of doing this. My use case was I want to skip @wip tags and run only @dev tags. I also added a little more to the test file to make sure this works properly.