### PR TITLE
Support coffeescript option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ but you can not open source the contributions.
 
 Example: `modulePath: "../../custom_libs/cucumberjs/lib/cucumber.js"`
 
+#### coffee
+Type: `Boolean`
+
+Default: `false`
+
+When true, cucumberjs will output code snippets in coffeescript
 
 ### Usage Examples
 

--- a/tasks/cucumber-js-task.js
+++ b/tasks/cucumber-js-task.js
@@ -12,6 +12,7 @@ module.exports = function (grunt) {
     var tags = options.tags;
     var format = options.format;
     var modulePath = options.modulePath;
+    var coffee = options.coffee;
 
     grunt.verbose.writeflags(options, 'Options');
 
@@ -60,6 +61,10 @@ module.exports = function (grunt) {
     if (! _.isEmpty(format)) {
       execOptions.push('-f');
       execOptions.push(format);
+    }
+
+    if (coffee) {
+      execOptions.push('--coffee');
     }
 
     var cucumberPath = 'cucumber';


### PR DESCRIPTION
cucumber-js 0.3.3 added support for coffeescript snippets.  This PR
allows that flag to be set in the gruntfile.